### PR TITLE
Weighted solute-solvent contributions

### DIFF
--- a/clusttraj/distmat.py
+++ b/clusttraj/distmat.py
@@ -65,6 +65,7 @@ def build_distance_matrix(clust_opt: ClustOptions) -> np.ndarray:
         itertools.repeat(clust_opt.no_hydrogen),
         itertools.repeat(clust_opt.reorder_alg),
         itertools.repeat(clust_opt.solute_natoms),
+        itertools.repeat(clust_opt.weight_solute),
         itertools.repeat(clust_opt.reorder_excl),
         itertools.repeat(clust_opt.final_kabsch),
     )
@@ -87,6 +88,7 @@ def compute_distmat_line(
         Callable[[np.ndarray, np.ndarray, np.ndarray, np.ndarray], np.ndarray], None
     ],
     nsatoms: int,
+    weight_solute: float,
     reorderexcl: np.ndarray,
     final_kabsch: bool,
 ) -> List[float]:
@@ -220,36 +222,6 @@ def compute_distmat_line(
                 # rotate the whole system with this rotation
                 P = np.dot(P, U)
 
-                # consider only the solvent atoms in the reorder (without exclusions)
-                # solvexcl = np.where(reorderexcl >= natoms)
-                # solvview = np.delete(np.arange(natoms, len(P)), reorderexcl[solvexcl])
-                # Pview = P[solvview]
-                # Paview = Pa[solvview]
-
-                # # reorder just these atoms
-                # prr = reorder(Qa[solvview], Paview, Q[solvview], Pview)
-                # Pview = Pview[prr]
-                # Paview = Paview[prr]
-
-                # # build the total molecule with the reordered atoms
-                # whereins = np.where(
-                #     np.isin(np.arange(natoms, len(P)), reorderexcl[solvexcl]) == True
-                # )
-                # Psolv = np.insert(
-                #     Pview,
-                #     [x - whereins[0].tolist().index(x) for x in whereins[0]],
-                #     P[reorderexcl[solvexcl]],
-                #     axis=0,
-                # )
-                # Pasolv = np.insert(
-                #     Paview,
-                #     [x - whereins[0].tolist().index(x) for x in whereins[0]],
-                #     Pa[reorderexcl[solvexcl]],
-                #     axis=0,
-                # )
-
-                # Pr = np.concatenate((P[:natoms], Psolv))
-                # Pra = np.concatenate((Pa[:natoms], Pasolv))
         else:
             # Kabsch rotation
             U = rmsd.kabsch(P, Q)
@@ -283,10 +255,25 @@ def compute_distmat_line(
         else:
             Pr = P
 
+        # compute the weights
+        if weight_solute:
+            W = np.zeros(Pr.shape[0])
+            W[:natoms] = weight_solute / natoms
+            W[natoms:] = (1.0 - weight_solute) / (Pr.shape[0] - natoms)
+
         # for solute solvent alignement, compute RMSD without Kabsch
         if nsatoms and reorder and not final_kabsch:
-            distmat.append(rmsd.rmsd(Pr, Q))
+            if weight_solute:
+                diff = Pr - Q
+                distmat.append(
+                    np.sqrt(np.dot(W, np.sum(diff * diff, axis=1)) / Pr.shape[0])
+                )
+            else:
+                distmat.append(rmsd.rmsd(Pr, Q))
         else:
-            distmat.append(rmsd.kabsch_rmsd(Pr, Q))
+            if weight_solute:
+                distmat.append(rmsd.kabsch_weighted_rmsd(Pr, Q, W))
+            else:
+                distmat.append(rmsd.kabsch_rmsd(Pr, Q))
 
     return distmat

--- a/clusttraj/distmat.py
+++ b/clusttraj/distmat.py
@@ -64,6 +64,7 @@ def build_distance_matrix(clust_opt: ClustOptions) -> np.ndarray:
         itertools.repeat(clust_opt.trajfile),
         itertools.repeat(clust_opt.no_hydrogen),
         itertools.repeat(clust_opt.reorder_alg),
+        itertools.repeat(clust_opt.reorder_solvent_only),
         itertools.repeat(clust_opt.solute_natoms),
         itertools.repeat(clust_opt.weight_solute),
         itertools.repeat(clust_opt.reorder_excl),
@@ -87,6 +88,7 @@ def compute_distmat_line(
     reorder: Union[
         Callable[[np.ndarray, np.ndarray, np.ndarray, np.ndarray], np.ndarray], None
     ],
+    reorder_solvent_only: bool,
     nsatoms: int,
     weight_solute: float,
     reorderexcl: np.ndarray,
@@ -181,7 +183,7 @@ def compute_distmat_line(
             P = np.dot(P, U)
 
             # reorder solute atoms
-            if reorder:
+            if reorder and not reorder_solvent_only:
                 # find the solute atoms that are not excluded
                 soluexcl = np.where(reorderexcl < natoms)
                 soluteview = np.delete(np.arange(natoms), reorderexcl[soluexcl])

--- a/clusttraj/io.py
+++ b/clusttraj/io.py
@@ -99,7 +99,7 @@ class ClustOptions:
         # reordering options
         if self.reorder:
             if self.solute_natoms:
-                return_str += "\nUsing solute-solvent reordering\n"
+                return_str += "\nUsing solute-solvent adjustment/reordering\n"
                 if self.final_kabsch:
                     return_str += "Using final Kabsch rotation before computing RMSD\n"
                 return_str += f"Number of solute atoms: {self.solute_natoms}\n"
@@ -107,6 +107,8 @@ class ClustOptions:
                     return_str += f"Weight of the solute atoms: {self.weight_solute}\n"
                 else:
                     return_str += "Unweighted RMSD according to solute/solvent.\n"
+                if self.reorder_solvent_only:
+                    return_str += "Reordering only solvent atoms\n"
             else:
                 return_str += "\nReordering all atom at the same time\n"
 

--- a/clusttraj/io.py
+++ b/clusttraj/io.py
@@ -537,7 +537,11 @@ def configure_runtime(args_in: List[str]) -> ClustOptions:
             "The list of atoms to exclude for reordering only makes sense if reordering is enabled. Ignoring the list."
         )
 
-    if args.weight_solute and not args.solute_natoms:
+    if args.natoms_solute:
+        if args.natoms_solute < 0:
+            parser.error("The number of solute atoms must be a positive integer.")
+
+    if args.weight_solute and not args.natoms_solute:
         parser.error(
             "You must specify the number of solute atoms with -ns to use the -ws option."
         )

--- a/clusttraj/io.py
+++ b/clusttraj/io.py
@@ -102,6 +102,10 @@ class ClustOptions:
                 if self.final_kabsch:
                     return_str += "Using final Kabsch rotation before computing RMSD\n"
                 return_str += f"Number of solute atoms: {self.solute_natoms}\n"
+                if self.weight_solute:
+                    return_str += f"Weight of the solute atoms: {self.weight_solute}\n"
+                else:
+                    return_str += "Unweighted RMSD according to solute/solvent.\n"
             else:
                 return_str += "\nReordering all atom at the same time\n"
 

--- a/clusttraj/main.py
+++ b/clusttraj/main.py
@@ -65,6 +65,7 @@ def main(args: List[str] = None) -> None:
             distmat,
             clust_opt.no_hydrogen,
             clust_opt.reorder_alg,
+            clust_opt.reorder_solvent_only,
             clust_opt.solute_natoms,
             clust_opt.weight_solute,
             clust_opt.out_conf_name,

--- a/clusttraj/main.py
+++ b/clusttraj/main.py
@@ -66,6 +66,7 @@ def main(args: List[str] = None) -> None:
             clust_opt.no_hydrogen,
             clust_opt.reorder_alg,
             clust_opt.solute_natoms,
+            clust_opt.weight_solute,
             clust_opt.out_conf_name,
             clust_opt.out_conf_fmt,
             clust_opt.reorder_excl,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -31,6 +31,7 @@ def options_dict(tmp_path):
         "reorder_alg_name": "hungarian",
         "reorder_alg": None,
         "reorder": False,
+        "reorder_solvent_only": False,
         "input_distmat": False,
         "distmat_name": "test/ref/test_distmat.npy",
         "summary_name": os.path.join(tmp_path, "clusters.out"),

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -48,6 +48,7 @@ def options_dict(tmp_path):
         "no_hydrogen": True,
         "opt_order": False,
         "solute_natoms": 17,
+        "weight_solute": None,
         "overwrite": True,
         "final_kabsch": False,
         "silhouette_score": False,

--- a/test/test_distmat.py
+++ b/test/test_distmat.py
@@ -24,6 +24,7 @@ def test_compute_distmat_line(options_dict, clust_opt, first_conf_traj, test_dis
         clust_opt.no_hydrogen,
         None,
         clust_opt.solute_natoms,
+        clust_opt.weight_solute,
         clust_opt.reorder_excl,
         clust_opt.final_kabsch,
     )

--- a/test/test_distmat.py
+++ b/test/test_distmat.py
@@ -23,6 +23,7 @@ def test_compute_distmat_line(options_dict, clust_opt, first_conf_traj, test_dis
         clust_opt.trajfile,
         clust_opt.no_hydrogen,
         None,
+        clust_opt.reorder_solvent_only,
         clust_opt.solute_natoms,
         clust_opt.weight_solute,
         clust_opt.reorder_excl,
@@ -34,6 +35,35 @@ def test_compute_distmat_line(options_dict, clust_opt, first_conf_traj, test_dis
     assert len(line) == 2
     assert line[0] == pytest.approx(test_distmat[0], abs=1e-8)
     assert line[1] == pytest.approx(test_distmat[1], abs=1e-8)
+
+
+def test_compute_distmat_line_reorder_weight_solute(
+    options_dict, clust_opt, first_conf_traj
+):
+    # test just the options
+    # TODO: need distmat to check
+    clust_opt.reorder_alg = "hungarian"
+    clust_opt.reorder_solvent_only = True
+    clust_opt.solute_natoms = 17
+    clust_opt.weight_solute = 0.8
+    clust_opt.reorder_excl = [1, 2, 3]
+    clust_opt.final_kabsch = True
+    clust_opt.no_hydrogen = False
+
+    line = compute_distmat_line(
+        0,
+        get_mol_info(first_conf_traj),
+        clust_opt.trajfile,
+        clust_opt.no_hydrogen,
+        None,
+        clust_opt.reorder_solvent_only,
+        clust_opt.solute_natoms,
+        clust_opt.weight_solute,
+        clust_opt.reorder_excl,
+        clust_opt.final_kabsch,
+    )
+
+    assert len(line) == 2
 
 
 def test_build_distance_matrix(clust_opt, test_distmat):

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -23,6 +23,7 @@ def test_ClustOptions(options_dict):
     assert clust_opt.reorder_alg_name == "hungarian"
     assert clust_opt.reorder_alg is None
     assert clust_opt.reorder is False
+    assert clust_opt.reorder_solvent_only is False
     assert clust_opt.input_distmat is False
     assert clust_opt.distmat_name == "test/ref/test_distmat.npy"
     assert os.path.basename(clust_opt.summary_name) == "clusters.out"
@@ -40,6 +41,7 @@ def test_ClustOptions(options_dict):
     assert clust_opt.no_hydrogen is True
     assert clust_opt.opt_order is False
     assert clust_opt.solute_natoms == 17
+    assert clust_opt.weight_solute is None
     assert clust_opt.overwrite is True
     assert clust_opt.final_kabsch is False
     assert clust_opt.silhouette_score is False
@@ -69,6 +71,7 @@ def test_parse_args():
         reorder_exclusions=[1, 2, 3],
         reorder_alg="hungarian",
         reorder=False,
+        reorder_solvent_only=False,
         input=True,
         outputdistmat="distmat.npy",
         outputclusters="clusters.dat",
@@ -97,6 +100,7 @@ def test_parse_args():
         reorder_exclusions=[1, 2, 3],
         reorder_alg="hungarian",
         reorder=True,
+        reorder_solvent_only=False,
         input=True,
         outputdistmat="distmat.npy",
         outputclusters="clusters.dat",
@@ -169,6 +173,7 @@ def test_save_clusters_config(clust_opt, clusters_seq, test_distmat):
         test_distmat,
         clust_opt.no_hydrogen,
         clust_opt.reorder_alg,
+        clust_opt.reorder_solvent_only,
         clust_opt.solute_natoms,
         clust_opt.weight_solute,
         clust_opt.out_conf_name,

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -170,6 +170,7 @@ def test_save_clusters_config(clust_opt, clusters_seq, test_distmat):
         clust_opt.no_hydrogen,
         clust_opt.reorder_alg,
         clust_opt.solute_natoms,
+        clust_opt.weight_solute,
         clust_opt.out_conf_name,
         clust_opt.out_conf_fmt,
         clust_opt.reorder_excl,

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -65,6 +65,7 @@ def test_extant_file():
 def test_parse_args():
     args = argparse.Namespace(
         natoms_solute=10,
+        weight_solute=None,
         reorder_exclusions=[1, 2, 3],
         reorder_alg="hungarian",
         reorder=False,
@@ -92,6 +93,7 @@ def test_parse_args():
 
     args = argparse.Namespace(
         natoms_solute=10,
+        weight_solute=None,
         reorder_exclusions=[1, 2, 3],
         reorder_alg="hungarian",
         reorder=True,


### PR DESCRIPTION
This PR implements different weights for the solute and solvent with `--weight-solute`, which can specify a float between 0 and 1 as the weight percentage of the solute (works only with `-ns`).