### PR TITLE
Add  option to cut dendrogram at a fixed cluster count

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,15 @@ or
 python -m clusttraj -h
 ```
 
-The mandatory arguments are the path to the file containing the trajectory (in a format that OpenBabel can read with Pybel), and either the maximum RMSD to join two configurations option (`-rmsd`) or the silhouette score option (`-ss`).
+The mandatory arguments are the path to the file containing the trajectory (in a format that OpenBabel can read with Pybel), and one clustering criterion: the maximum RMSD to join two configurations (`-rmsd`), the silhouette score option (`-ss`), or the number of clusters to generate (`-nc`/`--n-clusters`).
 ```
 clusttraj trajectory.xyz -rmsd 1.0
+```
+
+To cut the dendrogram to a fixed number of clusters, use `--n-clusters`:
+
+```
+clusttraj trajectory.xyz --n-clusters 5
 ```
 or
 ```

--- a/clusttraj/classify.py
+++ b/clusttraj/classify.py
@@ -110,6 +110,39 @@ def classify_structures(
     return Z, clusters
 
 
+def classify_structures_nclusters(
+    clust_opt: ClustOptions, distmat: np.ndarray
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Classify structures using a user-selected number of clusters.
+
+    Args:
+        clust_opt: The clustering options.
+        distmat: The RMSD matrix.
+
+    Returns:
+        A tuple containing the linkage matrix and the clusters.
+    """
+    Logger.logger.info(
+        f"Clustering using '{clust_opt.method}' method to join the clusters\n"
+    )
+    Z = hcl.linkage(distmat, clust_opt.method, optimal_ordering=clust_opt.opt_order)
+
+    n_snapshots = Z.shape[0] + 1
+    if clust_opt.n_clusters > n_snapshots:
+        raise ValueError(
+            f"Cannot request {clust_opt.n_clusters} clusters from {n_snapshots} snapshots"
+        )
+
+    clusters = hcl.cut_tree(Z, n_clusters=[clust_opt.n_clusters]).ravel() + 1
+
+    Logger.logger.info(
+        f"Saving clustering classification to {clust_opt.out_clust_name}\n"
+    )
+    np.savetxt(clust_opt.out_clust_name, clusters, fmt="%d")
+
+    return Z, clusters
+
+
 def find_medoids_from_clusters(distmat: np.ndarray, clusters: np.ndarray) -> np.ndarray:
     """Find the medoids of the clusters.
 

--- a/clusttraj/io.py
+++ b/clusttraj/io.py
@@ -63,6 +63,7 @@ class ClustOptions:
     overwrite: bool = None
     final_kabsch: bool = None
     silhouette_score: bool = None
+    n_clusters: int = None
     metrics: bool = None
     distmat_name: str = None
     out_clust_name: str = None
@@ -111,6 +112,8 @@ class ClustOptions:
             else:
                 raise ValueError("optimal_cut must be a float or np.ndarray")
             return_str += f"RMSD criterion found by silhouette: {scut}\n"
+        elif self.n_clusters is not None:
+            return_str += f"Number of clusters criterion: {self.n_clusters}\n"
         else:
             return_str += f"RMSD criterion: {self.min_rmsd}\n"
         return_str += f"Ignoring hydrogens?: {self.no_hydrogen}\n"
@@ -375,6 +378,12 @@ def configure_runtime(args_in: List[str]) -> ClustOptions:
         type=float,
         help="value of RMSD used to classify structures as similar",
     )
+    rmsd_criterion.add_argument(
+        "-nc",
+        "--n-clusters",
+        type=check_positive,
+        help="number of clusters to generate by cutting the dendrogram",
+    )
 
     io_group = parser.add_mutually_exclusive_group()
     io_group.add_argument(
@@ -518,6 +527,7 @@ def parse_args(args: argparse.Namespace) -> ClustOptions:
         "overwrite": args.force,
         "final_kabsch": args.final_kabsch,
         "silhouette_score": args.silhouette_score,
+        "n_clusters": args.n_clusters,
         "metrics": args.metrics,
         "verbose": args.verbose,
     }

--- a/clusttraj/main.py
+++ b/clusttraj/main.py
@@ -13,6 +13,7 @@ from .distmat import get_distmat
 from .plot import plot_clust_evo, plot_dendrogram, plot_mds, plot_tsne
 from .classify import (
     classify_structures,
+    classify_structures_nclusters,
     classify_structures_silhouette,
     find_medoids_from_clusters,
     sum_distmat,
@@ -49,10 +50,16 @@ def main(args: List[str] = None) -> None:
 
     # perform the clustering
     start_time = time.monotonic()
-    if clust_opt.silhouette_score:
-        Z, clusters = classify_structures_silhouette(clust_opt, distmat)
-    else:
-        Z, clusters = classify_structures(clust_opt, distmat)
+    try:
+        if clust_opt.silhouette_score:
+            Z, clusters = classify_structures_silhouette(clust_opt, distmat)
+        elif clust_opt.n_clusters is not None:
+            Z, clusters = classify_structures_nclusters(clust_opt, distmat)
+        else:
+            Z, clusters = classify_structures(clust_opt, distmat)
+    except ValueError as exc:
+        Logger.logger.error(f"{exc}\n")
+        raise SystemExit(str(exc)) from exc
     end_time = time.monotonic()
     if clust_opt.verbose:
         Logger.logger.info(f"Time spent clustering: {end_time - start_time:.6f} s\n")

--- a/clusttraj/plot.py
+++ b/clusttraj/plot.py
@@ -12,6 +12,22 @@ import numpy as np
 from .io import ClustOptions, Logger
 
 
+def _nclusters_cut_height(Z: np.ndarray, n_clusters: int) -> float:
+    """Return a visual dendrogram cut height for a requested cluster count."""
+    n_snapshots = Z.shape[0] + 1
+    heights = Z[:, 2]
+
+    if n_clusters >= n_snapshots:
+        return 0.0
+    if n_clusters <= 1:
+        return heights[-1]
+
+    lower_merge = n_snapshots - n_clusters - 1
+    upper_merge = n_snapshots - n_clusters
+
+    return (heights[lower_merge] + heights[upper_merge]) / 2.0
+
+
 def plot_clust_evo(clust_opt: ClustOptions, clusters: np.ndarray) -> None:
     """Plot the evolution of cluster classification over the given samples.
 
@@ -85,6 +101,9 @@ def plot_dendrogram(
             threshold = clust_opt.optimal_cut
         else:
             raise ValueError("optimal_cut must be a float or np.ndarray")
+    elif clust_opt.n_clusters is not None:
+        threshold = _nclusters_cut_height(Z, clust_opt.n_clusters)
+        plt.axhline(threshold, linestyle="--", linewidth=2, color=line_color)
     else:
         plt.axhline(clust_opt.min_rmsd, linestyle="--", linewidth=2, color=line_color)
         threshold = clust_opt.min_rmsd

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -14,11 +14,17 @@ or
 
 	python -m clusttraj -h
 
-The only mandatory argument are the path to the file containing the trajectory (in a format that OpenBabel can read with Pybel) and the maximum RMSD between two configurations for them to be considered of the same cluster.
+The mandatory arguments are the path to the file containing the trajectory (in a format that OpenBabel can read with Pybel) and one clustering criterion: the maximum RMSD between two configurations for them to be considered of the same cluster, a silhouette-selected RMSD threshold, or a fixed number of clusters.
 
 .. code-block:: console
 
 	clusttraj trajectory.xyz -rmsd <threshold>
+
+To cut the dendrogram to a fixed number of clusters, use ``--n-clusters``:
+
+.. code-block:: bash
+
+	clusttraj trajectory.xyz --n-clusters 5
 
 Instead of fixing the RMSD, one can use the ``-ss`` flag to determine the threshold as the value that maximize the `silhouette coefficient <https://en.wikipedia.org/wiki/Silhouette_(clustering)>`_ metric:
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -33,7 +33,7 @@ def options_dict(tmp_path):
         "reorder": False,
         "reorder_solvent_only": False,
         "input_distmat": False,
-        "distmat_name": "test/ref/test_distmat.npy",
+        "distmat_name": os.path.join(tmp_path, "distmat.npy"),
         "summary_name": os.path.join(tmp_path, "clusters.out"),
         "evo_name": os.path.join(tmp_path, "clusters_evo.pdf"),
         "dendrogram_name": os.path.join(tmp_path, "clusters_dendrogram.pdf"),
@@ -53,6 +53,7 @@ def options_dict(tmp_path):
         "overwrite": True,
         "final_kabsch": False,
         "silhouette_score": False,
+        "n_clusters": None,
     }
 
     return options_dict

--- a/test/test_classify.py
+++ b/test/test_classify.py
@@ -9,9 +9,7 @@ def test_classify_structures(clust_opt, test_distmat, Z_matrix, clusters_seq):
     assert clusters == pytest.approx(clusters_seq, abs=1e-8)
 
 
-def test_classify_structures_nclusters_two_clusters(
-    clust_opt, test_distmat, Z_matrix
-):
+def test_classify_structures_nclusters_two_clusters(clust_opt, test_distmat, Z_matrix):
     clust_opt.n_clusters = 2
 
     Z, clusters = classify_structures_nclusters(clust_opt, test_distmat)
@@ -20,9 +18,7 @@ def test_classify_structures_nclusters_two_clusters(
     assert clusters == pytest.approx([1, 1, 2], abs=1e-8)
 
 
-def test_classify_structures_nclusters_three_clusters(
-    clust_opt, test_distmat, Z_matrix
-):
+def test_classify_structures_nclusters_three_clusters(clust_opt, test_distmat, Z_matrix):
     clust_opt.n_clusters = 3
 
     Z, clusters = classify_structures_nclusters(clust_opt, test_distmat)

--- a/test/test_classify.py
+++ b/test/test_classify.py
@@ -1,5 +1,5 @@
 import pytest
-from clusttraj.classify import classify_structures
+from clusttraj.classify import classify_structures, classify_structures_nclusters
 
 
 def test_classify_structures(clust_opt, test_distmat, Z_matrix, clusters_seq):
@@ -7,3 +7,32 @@ def test_classify_structures(clust_opt, test_distmat, Z_matrix, clusters_seq):
 
     assert Z == pytest.approx(Z_matrix, abs=1e-8)
     assert clusters == pytest.approx(clusters_seq, abs=1e-8)
+
+
+def test_classify_structures_nclusters_two_clusters(
+    clust_opt, test_distmat, Z_matrix
+):
+    clust_opt.n_clusters = 2
+
+    Z, clusters = classify_structures_nclusters(clust_opt, test_distmat)
+
+    assert Z == pytest.approx(Z_matrix, abs=1e-8)
+    assert clusters == pytest.approx([1, 1, 2], abs=1e-8)
+
+
+def test_classify_structures_nclusters_three_clusters(
+    clust_opt, test_distmat, Z_matrix
+):
+    clust_opt.n_clusters = 3
+
+    Z, clusters = classify_structures_nclusters(clust_opt, test_distmat)
+
+    assert Z == pytest.approx(Z_matrix, abs=1e-8)
+    assert clusters == pytest.approx([1, 2, 3], abs=1e-8)
+
+
+def test_classify_structures_nclusters_too_many_clusters(clust_opt, test_distmat):
+    clust_opt.n_clusters = 4
+
+    with pytest.raises(ValueError, match="Cannot request 4 clusters"):
+        classify_structures_nclusters(clust_opt, test_distmat)

--- a/test/test_distmat.py
+++ b/test/test_distmat.py
@@ -10,6 +10,7 @@ def test_get_distmat(options_dict, test_distmat):
     assert distmat == pytest.approx(test_distmat, abs=1e-8)
 
     options_dict["input_distmat"] = True
+    options_dict["distmat_name"] = "test/ref/test_distmat.npy"
     distmat = get_distmat(ClustOptions(**options_dict))
     assert len(distmat) == 3
     assert distmat == pytest.approx(test_distmat, abs=1e-8)

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -25,7 +25,7 @@ def test_ClustOptions(options_dict):
     assert clust_opt.reorder is False
     assert clust_opt.reorder_solvent_only is False
     assert clust_opt.input_distmat is False
-    assert clust_opt.distmat_name == "test/ref/test_distmat.npy"
+    assert os.path.basename(clust_opt.distmat_name) == "distmat.npy"
     assert os.path.basename(clust_opt.summary_name) == "clusters.out"
     assert os.path.basename(clust_opt.evo_name) == "clusters_evo.pdf"
     assert os.path.basename(clust_opt.dendrogram_name) == "clusters_dendrogram.pdf"
@@ -86,6 +86,7 @@ def test_parse_args():
         force=True,
         final_kabsch=True,
         silhouette_score=False,
+        n_clusters=None,
         metrics=False,
         verbose=False,
     )
@@ -115,6 +116,7 @@ def test_parse_args():
         force=True,
         final_kabsch=True,
         silhouette_score=False,
+        n_clusters=None,
         metrics=False,
         verbose=False,
     )
@@ -132,6 +134,19 @@ def test_configure_runtime(caplog):
     assert clust_opt.min_rmsd == pytest.approx(1.0, abs=1e-8)
     assert clust_opt.n_workers == 1
     assert clust_opt.out_clust_name == "clusters.dat"
+
+    clust_opt = configure_runtime(
+        ["test/ref/testtraj.xyz", "--n-clusters", "2", "-np", "1"]
+    )
+
+    assert clust_opt.n_clusters == 2
+    assert clust_opt.min_rmsd is None
+    assert clust_opt.silhouette_score is False
+
+    with pytest.raises(SystemExit):
+        clust_opt = configure_runtime(
+            ["test/ref/testtraj.xyz", "--n-clusters", "2", "--min-rmsd", "1.0"]
+        )
 
     with pytest.raises(SystemExit):
         clust_opt = configure_runtime(

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 from clusttraj.main import main
 
 
@@ -19,3 +20,39 @@ def test_main(tmp_path):
 
     assert os.path.exists(os.path.join(tmp_path, "clusters.dat"))
     assert os.path.exists(os.path.join(tmp_path, "clusters.out"))
+
+
+def test_main_nclusters(tmp_path):
+    main(
+        [
+            "test/ref/testtraj.xyz",
+            "--n-clusters",
+            "2",
+            "-np",
+            "1",
+            "-i",
+            "test/ref/test_distmat.npy",
+            "-oc",
+            os.path.join(tmp_path, "clusters.dat"),
+        ]
+    )
+
+    assert os.path.exists(os.path.join(tmp_path, "clusters.dat"))
+    assert os.path.exists(os.path.join(tmp_path, "clusters.out"))
+
+
+def test_main_nclusters_too_many_clusters(tmp_path):
+    with pytest.raises(SystemExit, match="Cannot request 4 clusters"):
+        main(
+            [
+                "test/ref/testtraj.xyz",
+                "--n-clusters",
+                "4",
+                "-np",
+                "1",
+                "-i",
+                "test/ref/test_distmat.npy",
+                "-oc",
+                os.path.join(tmp_path, "clusters.dat"),
+            ]
+        )

--- a/test/test_plot.py
+++ b/test/test_plot.py
@@ -14,6 +14,14 @@ def test_plot_dendrogram(clust_opt, clusters_seq, Z_matrix):
     assert os.path.exists(clust_opt.dendrogram_name)
 
 
+def test_plot_dendrogram_nclusters(clust_opt, Z_matrix):
+    clust_opt.n_clusters = 2
+
+    assert plot_dendrogram(clust_opt, [1, 1, 2], Z_matrix) is None
+
+    assert os.path.exists(clust_opt.dendrogram_name)
+
+
 def test_plot_mds(clust_opt, clusters_seq, test_distmat):
     assert plot_mds(clust_opt, clusters_seq, test_distmat) is None
 


### PR DESCRIPTION
## Summary

Add a new `--n-clusters` (`-nc`) clustering criterion that cuts the
dendrogram at a fixed number of clusters, providing an alternative to
the existing RMSD-threshold and silhouette-score modes.

## Changes

### New CLI flag
- `--n-clusters` / `-nc` — mutually exclusive with `--min-rmsd` and `-ss`.
- Accepts a positive integer validated by `check_positive`.

### New classification function
- `classify_structures_nclusters` in `clusttraj/classify.py` — uses
  `scipy.cluster.hierarchy.cut_tree` to obtain the requested number of
  clusters from the linkage matrix. Raises `ValueError` if the requested
  count exceeds the number of snapshots.

### Visualisation
- `_nclusters_cut_height` helper in `clusttraj/plot.py` — interpolates
  a horizontal dashed line at the appropriate dendrogram height for
  the requested cluster count.

### Error handling
- `ValueError` exceptions from the new classification function (as well
  as existing ones) are caught in `main()`, logged, and cause a clean
  `SystemExit`.

### Documentation
- README and `docs/source/usage.rst` updated with usage examples.

### Tests
- Unit tests for `classify_structures_nclusters`: 2, 3, and too-many
  clusters (expecting `ValueError`).
- Integration test `test_main_nclusters` with 2 clusters.
- Integration test `test_main_nclusters_too_many_clusters` expecting
  `SystemExit`.
- Dendrogram plot test with `n_clusters=2`.
- `configure_runtime` test for the new flag, and mutual-exclusivity
  check (`--n-clusters 2 --min-rmsd 1.0` → `SystemExit`).
- Fixture updated: `distmat_name` now uses `tmp_path` to avoid
  contamination; `n_clusters=None` added to `options_dict`.