### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/clusttraj/__init__.py
+++ b/clusttraj/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 __all__ = [
     "main",


### PR DESCRIPTION
Update version from 1.0.0 to 1.1.0 for the next release after adding the `--n-clusters` feature.