### PR TITLE
Fix IndexError in silhouette score optimization

### DIFF
--- a/clusttraj/classify.py
+++ b/clusttraj/classify.py
@@ -30,7 +30,7 @@ def classify_structures_silhouette(
     Z = hcl.linkage(distmat, clust_opt.method, optimal_ordering=clust_opt.opt_order)
 
     # Initialize the score and threshold
-    ss_opt = np.float64()
+    ss_opt = np.float64(-1.0)
     t_opt = np.array([])
     labels_opt = np.array([])
 
@@ -55,8 +55,8 @@ def classify_structures_silhouette(
         # Update the values to the highest silhouette score
         if np.all(ss > ss_opt):
             ss_opt = ss
-            t_opt = t
-            labels_opt = hcl_labels
+            t_opt = np.array([t])
+            labels_opt = np.array([hcl_labels])
 
     Logger.logger.info(f"Highest silhouette score: {ss_opt:.5f}\n")
 
@@ -69,7 +69,7 @@ def classify_structures_silhouette(
         clusters = labels_opt[0]
     else:
         Logger.logger.info(f"Optimal RMSD threshold value: {t_opt[0]:.5f}\n")
-        clusters = labels_opt
+        clusters = labels_opt[0]
 
     clust_opt.update({"optimal_cut": t_opt})
 

--- a/test/test_classify.py
+++ b/test/test_classify.py
@@ -1,13 +1,30 @@
 import pytest
-from clusttraj.classify import classify_structures, classify_structures_nclusters, classify_structures_silhouette
+from clusttraj.classify import (
+    classify_structures,
+    classify_structures_nclusters,
+    classify_structures_silhouette,
+)
 
 
 def test_classify_structures_silhouette(clust_opt):
     import numpy as np
-    # This distmat reliably yields a single optimal threshold, causing an IndexError
-    distmat = np.array([0.8914448312585805, 1.016370717302439, 1.0770540172126273, 0.5262279763713829, 0.9056642470478309, 0.7088570464110961, 0.49162431604355217, 0.8800215058217346, 0.6122727896102328, 0.7668009091886758])
-    classify_structures_silhouette(clust_opt, distmat, dstep=0.1)
 
+    # This distmat reliably yields a single optimal threshold, causing an IndexError
+    distmat = np.array(
+        [
+            0.8914448312585805,
+            1.016370717302439,
+            1.0770540172126273,
+            0.5262279763713829,
+            0.9056642470478309,
+            0.7088570464110961,
+            0.49162431604355217,
+            0.8800215058217346,
+            0.6122727896102328,
+            0.7668009091886758,
+        ]
+    )
+    classify_structures_silhouette(clust_opt, distmat, dstep=0.1)
 
 
 def test_classify_structures(clust_opt, test_distmat, Z_matrix, clusters_seq):

--- a/test/test_classify.py
+++ b/test/test_classify.py
@@ -1,5 +1,13 @@
 import pytest
-from clusttraj.classify import classify_structures, classify_structures_nclusters
+from clusttraj.classify import classify_structures, classify_structures_nclusters, classify_structures_silhouette
+
+
+def test_classify_structures_silhouette(clust_opt):
+    import numpy as np
+    # This distmat reliably yields a single optimal threshold, causing an IndexError
+    distmat = np.array([0.8914448312585805, 1.016370717302439, 1.0770540172126273, 0.5262279763713829, 0.9056642470478309, 0.7088570464110961, 0.49162431604355217, 0.8800215058217346, 0.6122727896102328, 0.7668009091886758])
+    classify_structures_silhouette(clust_opt, distmat, dstep=0.1)
+
 
 
 def test_classify_structures(clust_opt, test_distmat, Z_matrix, clusters_seq):


### PR DESCRIPTION
## Description
Fixes an `IndexError` that occurs when using the silhouette score (`-ss`) option and the clustering process determines that exactly one threshold yields the highest silhouette score.

Closes #25

## Changes
- Modified `classify_structures_silhouette` in `clusttraj/classify.py` to ensure that `t_opt` and `labels_opt` always remain numpy arrays, preventing them from being reassigned to scalar variables when exactly one optimal threshold is found.
- Initialized `ss_opt` to `-1.0` (minimum bounds) to guarantee a proper baseline comparison against valid silhouette scores.
- Added a targeted test `test_classify_structures_silhouette` to `test/test_classify.py`, utilizing a specific distance matrix known to reliably trigger the `IndexError`, verifying the fix and preventing regressions.

## Validation
- The full test suite (`pytest`) executes successfully.
- The new regression test successfully isolates and checks the specific condition that generated the `IndexError`.
